### PR TITLE
feat(trades): add "Sync Since Last Trade" button with dynamic date range

### DIFF
--- a/docs/trades-and-executions-sync.md
+++ b/docs/trades-and-executions-sync.md
@@ -111,7 +111,10 @@ Read API (`src/api/routers/trades.py`):
 - `GET /api/v1/trades`
 - `GET /api/v1/trades/{trade_id}`
 - `GET /api/v1/trades/{trade_id}/executions`
-- `POST /api/v1/trades/sync/flex-query`
+- `POST /api/v1/trades/sync/flex-query` — accepts a fixed lookback (`days`),
+  an explicit `start_date`/`end_date`, or `since_last_trade: true` (derives the
+  window from the latest execution date across all accounts through the
+  previous business day; the response echoes the computed `start_date`/`end_date`).
 
 Responses expose `data_source`, `flex_transaction_id`, `sec_type`, `exec_role`.
 Realized PnL is currently computed on read from `raw` (see

--- a/frontend/src/components/TradesTable.tsx
+++ b/frontend/src/components/TradesTable.tsx
@@ -625,7 +625,10 @@ export default function TradesTable() {
     return map;
   }, [filteredRows]);
 
-  const kickOffTradesSync = async (lookbackDays: number, label: string) => {
+  const kickOffTradesSync = async (
+    label: string,
+    options: { days?: number; sinceLastTrade?: boolean },
+  ) => {
     setSyncing(true);
     setSyncMessage(null);
     setSyncError(null);
@@ -637,15 +640,25 @@ export default function TradesTable() {
           source: "manual-ui",
           request_text: `${label} (flex query) from Trades page.`,
           max_attempts: 3,
-          days: lookbackDays,
+          ...(options.days !== undefined ? { days: options.days } : {}),
+          ...(options.sinceLastTrade ? { since_last_trade: true } : {}),
         }),
       });
       if (!res.ok) {
         throw new Error(await readErrorMessage(res, "Unable to queue sync"));
       }
-      const data: { job_id: number; status: string } = await res.json();
+      const data: {
+        job_id: number;
+        status: string;
+        start_date?: string | null;
+        end_date?: string | null;
+      } = await res.json();
+      const rangeNote =
+        data.start_date && data.end_date
+          ? ` Syncing ${data.start_date} → ${data.end_date}.`
+          : "";
       setSyncMessage(
-        `Queued ${label.toLowerCase()} job #${data.job_id} (${data.status}).`,
+        `Queued ${label.toLowerCase()} job #${data.job_id} (${data.status}).${rangeNote}`,
       );
       window.setTimeout(() => {
         void loadExecutions().catch(() => {});
@@ -679,7 +692,7 @@ export default function TradesTable() {
         <div className="flex items-center gap-2">
           <button
             onClick={() => {
-              void kickOffTradesSync(1, "Quick sync");
+              void kickOffTradesSync("Quick sync", { days: 1 });
             }}
             disabled={syncing}
             className="rounded border border-blue-300 px-3 py-1 text-sm text-blue-700 hover:bg-blue-50 disabled:opacity-50"
@@ -688,7 +701,7 @@ export default function TradesTable() {
           </button>
           <button
             onClick={() => {
-              void kickOffTradesSync(7, "Full sync");
+              void kickOffTradesSync("Full sync", { days: 7 });
             }}
             disabled={syncing}
             className="rounded border border-blue-300 px-3 py-1 text-sm text-blue-700 hover:bg-blue-50 disabled:opacity-50"
@@ -697,12 +710,24 @@ export default function TradesTable() {
           </button>
           <button
             onClick={() => {
-              void kickOffTradesSync(30, "Extended sync");
+              void kickOffTradesSync("Extended sync", { days: 30 });
             }}
             disabled={syncing}
             className="rounded border border-blue-300 px-3 py-1 text-sm text-blue-700 hover:bg-blue-50 disabled:opacity-50"
           >
             {syncing ? "Queueing..." : "Extended Sync (30d)"}
+          </button>
+          <button
+            onClick={() => {
+              void kickOffTradesSync("Sync since last trade", {
+                sinceLastTrade: true,
+              });
+            }}
+            disabled={syncing}
+            title="Sync from the most recent trade date across all accounts through today"
+            className="rounded border border-blue-300 px-3 py-1 text-sm text-blue-700 hover:bg-blue-50 disabled:opacity-50"
+          >
+            {syncing ? "Queueing..." : "Sync Since Last Trade"}
           </button>
         </div>
       </div>

--- a/src/api/routers/trades.py
+++ b/src/api/routers/trades.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
-from sqlalchemy import case, select
+from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session
 
 from src.api.deps import get_db
@@ -16,6 +16,7 @@ from src.services.jobs import (
     JOB_TYPE_TRADES_SYNC_TWS,
     enqueue_job,
 )
+from src.services.trade_sync_flexquery import previous_business_day
 from src.utils.contract_display import contract_display_name
 
 router = APIRouter()
@@ -391,6 +392,7 @@ class FlexTradeSyncRequest(BaseModel):
     account_code: str | None = None
     start_date: str | None = None
     end_date: str | None = None
+    since_last_trade: bool = False
     max_attempts: int = 3
 
 
@@ -398,6 +400,8 @@ class TradeSyncResponse(BaseModel):
     job_id: int
     job_type: str
     status: str
+    start_date: str | None = None
+    end_date: str | None = None
 
 
 @router.get("/trades", response_model=list[TradeResponse])
@@ -827,9 +831,34 @@ def enqueue_flex_trades_sync(
     payload: dict[str, object] = {"days": body.days}
     if body.account_code:
         payload["account_code"] = body.account_code
-    if body.start_date and body.end_date:
-        payload["start_date"] = body.start_date
-        payload["end_date"] = body.end_date
+    start_date_str: str | None = None
+    end_date_str: str | None = None
+    if body.since_last_trade:
+        latest_executed_at = max(
+            (
+                value
+                for value in (
+                    db.execute(select(func.max(TradeExecution.executed_at))).scalar(),
+                    db.execute(select(func.max(Trade.last_executed_at))).scalar(),
+                )
+                if value is not None
+            ),
+            default=None,
+        )
+        if latest_executed_at is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No existing trades found to sync from; use a fixed lookback sync instead.",
+            )
+        end_date = previous_business_day()
+        start_date_str = min(latest_executed_at.date(), end_date).isoformat()
+        end_date_str = end_date.isoformat()
+    elif body.start_date and body.end_date:
+        start_date_str = body.start_date
+        end_date_str = body.end_date
+    if start_date_str and end_date_str:
+        payload["start_date"] = start_date_str
+        payload["end_date"] = end_date_str
     job = enqueue_job(
         session=db,
         job_type=JOB_TYPE_TRADES_SYNC_FLEXQUERY,
@@ -843,4 +872,6 @@ def enqueue_flex_trades_sync(
         job_id=job.id,
         job_type=job.job_type,
         status=job.status,
+        start_date=start_date_str,
+        end_date=end_date_str,
     )


### PR DESCRIPTION
## Summary

Adds a fourth sync button on the Trades page — "Sync Since Last Trade" — next to the existing 1d/7d/30d buttons. Instead of a fixed lookback, it derives the sync window dynamically: start date is the latest execution date across all accounts, end date is the previous business day (FlexQuery is T-1 EOD). The UI message echoes the computed range so you can see exactly what will be synced.

## Features

- `POST /trades/sync/flex-query` accepts `since_last_trade: true`; the route computes the window from the greater of `max(trade_executions.executed_at)` and `max(trades.last_executed_at)`, and echoes `start_date`/`end_date` in the response.
- New "Sync Since Last Trade" button in the Trades page header; queued-job message shows the computed range (e.g. "Syncing 2026-06-05 → 2026-06-10").
- Edge cases: range clamps to a single day if the last trade is on/after the previous business day (idempotent upserts make overlap safe); returns 400 if no trades exist yet.

## Refactoring

- `kickOffTradesSync` now takes a label plus options (`days` or `sinceLastTrade`) instead of a positional days argument.

## Fixes

N/A

## Documentation

- `docs/trades-and-executions-sync.md`: documented the three accepted windowing modes on the flex-query sync endpoint.

https://claude.ai/code/session_017rE8HcdUzV5sDjJCgF3926

---
_Generated by [Claude Code](https://claude.ai/code/session_017rE8HcdUzV5sDjJCgF3926)_