### PR TITLE
docs: fix broken links, missing pages, and op run guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 New to the project? Follow the [Getting Started guide](docs/getting-started.md) for a full walkthrough covering prerequisites, database setup, IBKR configuration, and running the app.
 
-For a quick install reference, see [docs/install-python-and-frontend.md](docs/install-python-and-frontend.md).
-
 **You assume all risk.**
 
 ## License

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,6 +38,7 @@ Install these before proceeding:
 | Bun                    | 1.0+     | [bun.sh](https://bun.sh/)                                                           |
 | PostgreSQL             | 14+      | [postgresql.org](https://www.postgresql.org/download/) or `brew install postgresql` |
 | Task                   | latest   | [taskfile.dev](https://taskfile.dev/docs/installation)                              |
+| 1Password CLI (`op`)   | latest   | [developer.1password.com](https://developer.1password.com/docs/cli/get-started/) — required; all `task` commands embed `op run` |
 | IBKR TWS or IB Gateway | optional | [interactivebrokers.com](https://www.interactivebrokers.com/en/trading/tws.php)     |
 
 ## 1. Clone and Install Dependencies
@@ -109,14 +110,13 @@ DB_PASSWORD=op://MyVault/ngtrader-db/password
 BROKER_TWS_PORT=op://MyVault/ibkr/tws-port
 ```
 
-To resolve `op://` references, wrap any command with `op run`:
+To resolve `op://` references, wrap scripts that don't use the task runner directly:
 
 ```bash
-op run --env-file=.env.dev -- task api
 op run --env-file=.env.dev -- uv run python scripts/setup_db.py --env dev
 ```
 
-`op run` resolves the references and injects the real values as environment variables before the inner command starts. All `task` commands work with or without the `op run` wrapper — it's your choice.
+`op run` resolves the references and injects the real values as environment variables before the inner command starts. All `task` commands (e.g. `task api`, `task worker:jobs`) already embed `op run` internally — run them directly.
 
 See [secrets-using-1password.md](secrets-using-1password.md) for details.
 
@@ -240,14 +240,17 @@ See [workers.md](workers.md) for worker architecture details.
 
 ### Pages
 
-| Page            | URL           | What it does                                              |
-| --------------- | ------------- | --------------------------------------------------------- |
-| **Tradebot**    | `/tradebot`   | AI chat interface — ask about positions, trigger syncs    |
-| **Accounts**    | `/accounts`   | View IBKR accounts and set display aliases                |
-| **Positions**   | `/positions`  | View current holdings with filters, trigger position sync |
-| **Orders**      | `/orders`     | View synced orders and track fill status                  |
-| **Trades**      | `/trades`     | View executed trade history and fill details              |
-| **Watch Lists** | `/watchlists` | Create watchlists, add instruments, view live quotes      |
+| Page            | URL            | What it does                                              |
+| --------------- | -------------- | --------------------------------------------------------- |
+| **Tradebot**    | `/tradebot`    | AI chat interface — ask about positions, trigger syncs    |
+| **Accounts**    | `/accounts`    | View IBKR accounts and set display aliases                |
+| **Positions**   | `/positions`   | View current holdings with filters, trigger position sync |
+| **Orders**      | `/orders`      | View synced orders and track fill status                  |
+| **Trades**      | `/trades`      | View executed trade history and fill details              |
+| **Tagging**     | `/tagging`     | Organize executions into trade groups with strategy tags  |
+| **Watch Lists** | `/watchlists`  | Create watchlists, add instruments, view live quotes      |
+| **Market Data** | `/market-data` | Monitor futures and options market data                   |
+| **Structures**  | `/structures`  | Build and price options structures; view expected PnL     |
 
 ### Common workflows
 
@@ -287,13 +290,6 @@ task migrate:new -- "description"  # Create a new migration
 task worker:jobs       # Start jobs worker (position sync, quotes)
 task validate          # Check env file, Postgres, migrations, TWS
 task validate -- --no-tws     # Skip TWS connectivity check
-```
-
-To use 1Password, wrap any task command:
-
-```bash
-op run --env-file=.env.dev -- task api
-op run --env-file=.env.dev -- task worker:jobs
 ```
 
 To target production:

--- a/docs/secrets-using-1password.md
+++ b/docs/secrets-using-1password.md
@@ -37,18 +37,20 @@ When you run a command with `op run --env-file=<file>`, the 1Password CLI:
 
 ```bash
 # Dev
-op run --env-file=.env.dev -- uv run python scripts/example_env_vars.py --env dev
+op run --env-file=.env.dev -- uv run python scripts/setup_db.py --env dev
 
 # Prod
-op run --env-file=.env.prod -- uv run python scripts/example_env_vars.py --env prod
+op run --env-file=.env.prod -- uv run python scripts/setup_db.py --env prod
 ```
+
+Task commands (`task api`, `task worker:jobs`, etc.) already embed `op run` internally — run them directly without wrapping.
 
 ### Running without 1Password (plain dotenv only)
 
-If you don't need 1Password resolution (e.g., no `op://` refs in your env file), you can run directly:
+If you don't need 1Password resolution (e.g., no `op://` refs in your env file), you can run scripts directly:
 
 ```bash
-uv run python scripts/example_env_vars.py --env dev
+uv run python scripts/setup_db.py --env dev
 ```
 
 Note: any `op://` values will remain as literal strings in this case.
@@ -62,8 +64,6 @@ from dotenv import load_dotenv
 
 load_dotenv(".env.dev")  # no override — respects existing env vars
 ```
-
-See `scripts/example_env_vars.py` for a full working example.
 
 ## Adding new secrets
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -8,11 +8,11 @@ queues. Two workers exist.
 | `worker:jobs` | `scripts/work_jobs.py` | `jobs` table | Active |
 | `worker:orders` | `scripts/work_order_queue.py` | `orders` table | Scaffold only — **submission is disabled** |
 
-Start commands (run under `op run` to resolve `op://` secrets):
+Start commands:
 
 ```bash
-ENV=dev task worker:jobs
-ENV=dev task worker:orders
+task worker:jobs
+task worker:orders
 ```
 
 ## Jobs worker (`worker:jobs`)

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -11,8 +11,8 @@ queues. Two workers exist.
 Start commands:
 
 ```bash
-task worker:jobs
-task worker:orders
+task worker:jobs ENV=dev
+task worker:orders ENV=dev
 ```
 
 ## Jobs worker (`worker:jobs`)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,73 +1,38 @@
-# React + TypeScript + Vite
+# ngv-trader frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React + TypeScript + Vite UI for ngv-trader.
 
-Currently, two official plugins are available:
+## Stack
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- React 19 + React Router 7
+- TypeScript 5
+- Tailwind CSS 4
+- Bun (package manager)
+- Vite 7
 
-## React Compiler
+## Pages
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+| Route | Component | Purpose |
+|-------|-----------|---------|
+| `/tradebot` | `TradebotChat` | AI chat interface |
+| `/accounts` | `AccountsTable` | IBKR account management |
+| `/positions` | `PositionsTable` | Current portfolio positions |
+| `/orders` | `OrdersTable` | Order tracking |
+| `/trades` | `TradesTable` | Trade history and executions |
+| `/tagging` | `TradeTaggingPage` | Trade group and strategy tagging |
+| `/watchlists` | `WatchListsPage` | Instrument watch lists with live quotes |
+| `/market-data` | `MarketDataPage` | Futures and options market data |
+| `/structures` | `PricingPage` | Options structure builder and PnL calculator |
 
-## Expanding the ESLint configuration
+## Dev
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(["dist"]),
-  {
-    files: ["**/*.{ts,tsx}"],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ["./tsconfig.node.json", "./tsconfig.app.json"],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-]);
+```bash
+bun install
+bun run dev     # port 5173
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Or from the repo root: `task frontend`.
 
-```js
-// eslint.config.js
-import reactX from "eslint-plugin-react-x";
-import reactDom from "eslint-plugin-react-dom";
+## API
 
-export default defineConfig([
-  globalIgnores(["dist"]),
-  {
-    files: ["**/*.{ts,tsx}"],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs["recommended-typescript"],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ["./tsconfig.node.json", "./tsconfig.app.json"],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-]);
-```
+Consumes `/api/v1/*` on the FastAPI backend (default port 8000). See `src/config.ts` for base URL config.


### PR DESCRIPTION
## Summary

Cross-checked all docs against the codebase (routes, scripts, Taskfile). Fixed broken references, missing pages, and misleading `op run` guidance introduced when task commands were updated to embed `op run` internally.

## Changes

| Priority | File | Change |
|---|---|---|
| High | `README.md` | Remove broken link to `docs/install-python-and-frontend.md` — file does not exist |
| High | `docs/getting-started.md` | Add 3 missing pages to the pages table: Tagging (`/tagging`), Market Data (`/market-data`), Structures (`/structures`) |
| High | `docs/getting-started.md` | Add `op` (1Password CLI) to Prerequisites — all `task` commands embed `op run` and require it installed |
| Medium | `docs/secrets-using-1password.md` | Replace 4 references to non-existent `scripts/example_env_vars.py` with `scripts/setup_db.py` |
| Medium | `docs/getting-started.md` | Remove redundant `op run -- task api` examples — task commands already embed `op run` internally; wrapping is a double-invocation |
| Medium | `docs/workers.md` | Remove misleading "run under `op run`" comment — task commands already handle this |
| Low | `docs/workers.md` | Use Task CLI variable syntax `task worker:jobs ENV=dev` (sets `{{.ENV}}` Task var) instead of shell prefix `ENV=dev task worker:jobs` |
| Low | `frontend/README.md` | Replace Vite template boilerplate with project-specific pages, stack, and dev instructions |