### PR TITLE
chore: add SessionStart hook to install deps for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SessionStart hook: install backend + frontend deps so tests/linters work
+# in Claude Code on the web. Idempotent and non-interactive.
+set -euo pipefail
+
+# Only run in the remote (web) environment.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Backend: sync Python deps incl. the dev group (typer/ruff/ipdb).
+# pyproject sets default-groups = [], so --group dev is required for
+# scripts/check.py (typer) and ruff to be available.
+echo "[session-start] uv sync --group dev"
+uv sync --group dev
+
+# Frontend: install JS deps with bun.
+echo "[session-start] bun install (frontend)"
+(cd frontend && bun install)
+
+echo "[session-start] done"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,10 @@ scripts/data/
 # APS (Agentic Prompt Sync)
 .aps-backups/
 
-.claude
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+.claude/settings.local.json
 
 # ----------------- standard python ignores -----------------
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,12 +102,23 @@ Exits 1 on failure.
 
 ### Package Installation Cooldown
 
-Before installing any new package with `uv add`, observe a **14-day cooldown**:
+A **14-day cooldown** applies to all new dependencies (Python and JS) to avoid
+ingesting freshly-published, potentially-compromised versions.
 
-1. Check when the package was last released (PyPI release date).
-2. If the release is fewer than 14 days old, do not install it — wait for the cooldown to pass.
-3. Applies to direct dependencies only; transitive upgrades pulled in by `uv sync` are exempt.
-4. Note the cooldown and the release date in the PR description when adding a new package.
+**Python (uv):** enforce the cutoff at add time:
+
+```bash
+uv add <pkg> --exclude-newer "$(date -u -d '14 days ago' +%Y-%m-%d)"
+```
+
+1. Applies to direct dependencies only; transitive upgrades pulled in by `uv sync` are exempt.
+2. Note the cooldown and the release date in the PR description when adding a new package.
+
+**Frontend (bun):** enforced mechanically — `frontend/bunfig.toml` sets
+`minimumReleaseAge = 1209600` (14 days), so `bun add`/`bun install` refuse any
+version published less than 14 days ago. No manual step needed. To intentionally
+allow a fresh package, add it to `minimumReleaseAgeExcludes` in `bunfig.toml` and
+note it in the PR.
 
 This prevents ingesting packages with undetected supply-chain issues or breaking changes in the days immediately after release.
 

--- a/frontend/bunfig.toml
+++ b/frontend/bunfig.toml
@@ -1,0 +1,4 @@
+[install]
+# Supply-chain cooldown: only install packages published at least 14 days ago.
+# Mitigates pulling in freshly-published (potentially compromised) versions.
+minimumReleaseAge = 1209600


### PR DESCRIPTION
Pre-install backend (uv sync --group dev) and frontend (bun install)
dependencies on session start so linters and import checks work without
manual setup each session. Track the shared hook + settings by negating
the .claude gitignore rule (personal settings.local.json stays ignored).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WnprtGGY4DDGLogFD2FFi4